### PR TITLE
Add "sideEffects": false to package.json

### DIFF
--- a/blob/package.json
+++ b/blob/package.json
@@ -71,5 +71,6 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-storage-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-storage-js#readme"
+  "homepage": "https://github.com/Azure/azure-storage-js#readme",
+  "sideEffects": false
 }


### PR DESCRIPTION
This PR adds the `"sideEffects": false` property to package.json. [See the example from Webpack](https://github.com/webpack/webpack/tree/master/examples/side-effects).

This flag gives Webpack 4 permission to assume that modules in this package don't cause side-effects when evaluated (i.e. adding or modifying variables in the global scope), which allows for better tree-shaking performance for end users. That is, the mere declaration of the classes and functions in the module doesn't cause side-effects--users need to call or instantiate the exported objects to cause side-effects.

Would like to create a sample *outside* of this package which imports and uses some small component from `@azure/storage-blob` in order to test the size difference made by this change.