### PR TITLE
Fix typo in file name in index

### DIFF
--- a/queue/lib/index.ts
+++ b/queue/lib/index.ts
@@ -12,7 +12,7 @@ export * from "./credentials/Credential";
 export * from "./credentials/SharedKeyCredential";
 export * from "./credentials/TokenCredential";
 export { IIPRange } from "./IIPRange";
-export * from "./MessageIdURL";
+export * from "./MessageIDURL";
 export * from "./MessagesURL";
 export * from "./Pipeline";
 export * from "./policies/AnonymousCredentialPolicy";


### PR DESCRIPTION
Currently this import into index.ts doesn't work on any OS that appreciates file case. Fixed to match casing of file.